### PR TITLE
A simple implementation of the GC mechanism

### DIFF
--- a/instruction_handlers.py
+++ b/instruction_handlers.py
@@ -139,7 +139,7 @@ class InstructionHandlers:
         if not prompt or not output_var:
             return self._handle_error("Missing 'prompt' or 'output_var' in parameters.")
 
-        interpolated_prompt = self.vm.variable_manager.interpolate_variables(prompt)
+        interpolated_prompt = self.vm.resolve_parameter(prompt)
         interpolated_context = self.vm.resolve_parameter(params.get('context'))
         response = self.vm.llm_interface.generate(interpolated_prompt, interpolated_context)
         

--- a/variable_manager.py
+++ b/variable_manager.py
@@ -1,28 +1,24 @@
 from typing import Any, Dict
 
+
 class VariableManager:
     def __init__(self):
         self.variables = {}
         self.variable_refs = {}
 
-    def set(self, var_name: str, value: Any) -> None:
-        if var_name in self.variables:
-            self.decrease_ref_count(var_name)
-        
+    def set(self, var_name: str, value: Any, reference_count: int = 1) -> None:
         self.variables[var_name] = value
-        self.variable_refs[var_name] = 1
+        self.variable_refs[var_name] = reference_count
+
+    def set_reference_count(self, var_name: str, reference_count: int) -> None:
+        self.variable_refs[var_name] = reference_count
 
     def get(self, var_name: str) -> Any:
-        if var_name in self.variables:
-            self.variable_refs[var_name] += 1
         return self.variables.get(var_name)
 
     def decrease_ref_count(self, var_name: str) -> None:
         if var_name in self.variable_refs:
             self.variable_refs[var_name] -= 1
-            if self.variable_refs[var_name] <= 0:
-                del self.variables[var_name]
-                del self.variable_refs[var_name]
 
     def garbage_collect(self) -> None:
         for var_name in list(self.variable_refs.keys()):
@@ -33,14 +29,34 @@ class VariableManager:
     def get_all_variables(self) -> Dict[str, Any]:
         return self.variables.copy()
 
-    def set_all_variables(self, variables: Dict[str, Any]) -> None:
+    def get_all_variables_reference_count(self) -> Dict[str, int]:
+        return self.variable_refs.copy()
+
+    def set_all_variables(
+        self, variables: Dict[str, Any], variables_refs: Dict[str, Any]
+    ) -> None:
         self.variables = variables.copy()
-        self.variable_refs = {k: 1 for k in variables}
+        self.variable_refs = variables_refs.copy()
 
     def interpolate_variables(self, text: Any) -> Any:
         """Interpolate variables in the given text."""
         if not isinstance(text, str):
             return text
-        for var, value in self.variables.items():
-            text = text.replace(f"${{{var}}}", str(value))
+        vars = self.find_referenced_variables(text)
+        for var in vars:
+            text = text.replace(f"${{{var}}}", str(self.variables.get(var)))
+            self.decrease_ref_count(var)
+
         return text
+
+    def find_referenced_variables(self, text: Any) -> list:
+        """Find and return a list of variables referenced in the given text."""
+        if not isinstance(text, str):
+            return []
+
+        referenced_vars = []
+        for var in self.variables.keys():
+            if f"${{{var}}}" in text:
+                referenced_vars.append(var)
+
+        return referenced_vars


### PR DESCRIPTION
1. When setting a variable, count the number of steps greater than the current program counter that reference this variable, and use that as the reference count.
2. During `interpolate_variables`, if this parameter is used, reduce the corresponding variable’s reference count by 1.
3. If the reference count reaches 0, delete the variable.

The code implementation is simple, and I will make slight adjustments later.