### PR TITLE
[Testing] Optimize Parallel

### DIFF
--- a/app/controller/api_routes.py
+++ b/app/controller/api_routes.py
@@ -530,7 +530,9 @@ def stream_execute_vm():
 
                     def execute_step():
                         nonlocal step_result
-                        step_result = task.vm.step(stream_queue=queue)
+                        step_result = task.vm.step(
+                            enable_parallel=True, stream_queue=queue
+                        )
 
                     step_thread = Thread(target=execute_step)
                     step_thread.start()

--- a/app/controller/task.py
+++ b/app/controller/task.py
@@ -101,10 +101,10 @@ class Task:
             self.vm.set_plan(plan)
         return plan
 
-    def _run(self):
+    def _run(self, enable_parallel=True):
         """Execute the plan for the task."""
         while True:
-            execution_result = self.vm.step()
+            execution_result = self.vm.step(enable_parallel=enable_parallel)
             if execution_result.get("success") is not True:
                 raise ValueError(
                     f"Failed to execute step:{execution_result.get('error')}"
@@ -190,7 +190,7 @@ class Task:
                 else:
                     raise ValueError("Failed to commit updated plan")
 
-                self._run()
+                self._run(enable_parallel=False)
                 return {
                     "success": True,
                     "current_branch": self.vm.branch_manager.get_current_branch(),
@@ -236,7 +236,7 @@ class Task:
                             last_commit_hash = new_commit_hash
 
                     try:
-                        execution_result = self.vm.step()
+                        execution_result = self.vm.step(enable_parallel=False)
                     except Exception as e:
                         error_msg = f"Error during VM step execution: {str(e)}"
                         logger.error(error_msg, exc_info=True)
@@ -337,7 +337,7 @@ class Task:
                         f"Failed to create or checkout branch '{branch_name}'"
                     )
 
-                self._run()
+                self._run(enable_parallel=False)
                 return {
                     "success": True,
                     "current_branch": self.vm.branch_manager.get_current_branch(),

--- a/app/instructions/instruction_handlers.py
+++ b/app/instructions/instruction_handlers.py
@@ -68,7 +68,7 @@ class InstructionHandlers:
                         raise ValueError(
                             f"Not found variable {var_name} in parsed_output {parsed_output}."
                         )
-                # self.vm.set_variable(var_name, var_value)
+                self.vm.set_variable(var_name, var_value)
                 output_vars_record[var_name] = var_value
 
             return True, output_vars_record
@@ -274,7 +274,7 @@ class InstructionHandlers:
         output_vars_record = {}
         for var_name, value in params.items():
             value_resolved = self.vm.resolve_parameter(value)
-            # self.vm.set_variable(var_name, value_resolved)
+            self.vm.set_variable(var_name, value_resolved)
             output_vars_record[var_name] = value_resolved
         return True, {"output_vars": output_vars_record}
 


### PR DESCRIPTION
This PR aims to further improve the concurrency performance of execution. To understand why this modification is necessary, let’s consider the following example:

```
vector_search_1
llm_generate(vector_search_1_res)
vector_search_2
llm_generate(vector_search_2_res)
vector_search_3
llm_generate(vector_search_3_res)
```

Ideally, tasks `(vector_search + llm_generate)` 1, 2, and 3 should execute completely concurrently. For example, when `vector_search_1` finishes executing, `vector_search_2` and `vector_search_3` have already completed and their results have been saved. 
However, this scenario causes issues with the update plan. If we execute an update plan after `vector_search_1` completes, aiming to optimize the queries for `vector_search_2` and `vector_search_3`, the results of `vector_search_2` and `vector_search_3` are already stored in variables. Consequently, `llm_generate_2` and `llm_generate_3` are immediately executed, rendering the optimizations for `vector_search_2` and `vector_search_3` ineffective.

Therefore, the update plan needs to be executed serially.